### PR TITLE
Hotfix: revert bumped versions in arapp.json...

### DIFF
--- a/apps/allocations/arapp.json
+++ b/apps/allocations/arapp.json
@@ -1,6 +1,6 @@
 {
   "appName": "allocations.aragonpm.eth",
-  "version": "7.0.0",
+  "version": "0.0.1",
   "roles": [
     {
       "name": "Initiate an allocations payout",

--- a/apps/range-voting/arapp.json
+++ b/apps/range-voting/arapp.json
@@ -1,6 +1,6 @@
 {
   "appName": "range-voting.aragonpm.eth",
-  "version": "21.0.0",
+  "version": "0.0.1",
   "roles": [
     {
       "name": "Create new votes",


### PR DESCRIPTION
 ...for allocations and range-voting

The hotfix is submitted because it prevents the apps to be published, disabling any chance to start the kit.