### PR TITLE
Tweak styles in Range Voting, Slider UI and others.

### DIFF
--- a/apps/allocations/arapp.json
+++ b/apps/allocations/arapp.json
@@ -1,6 +1,6 @@
 {
   "appName": "allocations.aragonpm.eth",
-  "version": "7.0.0",
+  "version": "0.0.1",
   "roles": [
     {
       "name": "Initiate an allocations payout",

--- a/apps/range-voting/app/components/Panels/VotePanelContent.js
+++ b/apps/range-voting/app/components/Panels/VotePanelContent.js
@@ -10,8 +10,7 @@ import {
   SidePanelSeparator,
   Countdown,
   Text,
-  theme,
-  Slider
+  theme
 } from '@aragon/ui'
 import { combineLatest } from '../../rxjs'
 import provideNetwork from '../../utils/provideNetwork'
@@ -20,6 +19,7 @@ import { safeDiv } from '../../utils/math-utils'
 import VoteSummary from '../VoteSummary'
 import VoteStatus from '../VoteStatus'
 import ProgressBarThick from '../ProgressBarThick'
+import Slider from '../Slider'
 
 class VotePanelContent extends React.Component {
   static propTypes = {
@@ -238,16 +238,24 @@ class VotePanelContent extends React.Component {
               {this.state.voteOptions.map((option, idx) => (
                 <div key={idx}>
                   <SliderAndValueContainer>
-                    <SliderContainer>
+                    <div style={{ display: 'flex', flexDirection: 'column' }}>
                       <Text size="small">{option.label}</Text>
+                      <div
+                        style={{
+                          display: 'flex',
+                          margin: '0.5rem 0 1rem 0'
+                        }}
+                      >
                       <Slider
+                          width="270px"
                         value={option.sliderValue}
                         onUpdate={value => this.sliderUpdate(value, idx)}
                       />
-                    </SliderContainer>
                     <ValueContainer>
                       {Math.round(option.sliderValue * 100) || 0}
                     </ValueContainer>
+                      </div>
+                    </div>
                   </SliderAndValueContainer>
                 </div>
               ))}
@@ -315,7 +323,7 @@ const AdjustContainer = styled.div`
 const ValueContainer = styled.div`
   box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 0.03);
   border-radius: 3px;
-  width: 70px;
+  width: 69px;
   height: 40px;
   border: 1px solid #e6e6e6;
   padding-top: 0.5rem;

--- a/apps/range-voting/app/components/Panels/VotePanelContent.js
+++ b/apps/range-voting/app/components/Panels/VotePanelContent.js
@@ -370,11 +370,6 @@ const ShowText = styled.p`
   cursor: pointer;
 `
 
-const SecondRedText = styled(Text)`
-  float: right;
-  margin-top: 0.5rem;
-`
-
 const Part = styled.div`
   padding: 20px 0;
   h2 {

--- a/apps/range-voting/app/components/Panels/VotePanelContent.js
+++ b/apps/range-voting/app/components/Panels/VotePanelContent.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import Blockies from 'react-blockies'
+import { BigNumber } from 'bignumber.js'
 import {
   Button,
   Info,
@@ -227,7 +228,10 @@ class VotePanelContent extends React.Component {
             <h2>
               <Label>Your voting tokens</Label>
             </h2>
-            <p>{this.state.userBalance}</p>
+            {BigNumber(this.state.userBalance)
+              .div(BigNumber(10e15))
+              .dp(3)
+              .toString()}
           </div>
         </SidePanelSplit>
         {open && (

--- a/apps/range-voting/app/components/Panels/VotePanelContent.js
+++ b/apps/range-voting/app/components/Panels/VotePanelContent.js
@@ -221,7 +221,10 @@ class VotePanelContent extends React.Component {
               <Label>Voter participation</Label>
             </h2>
             <p>
-              {participationPct}% <RedText>({minParticipationPct/ (10**16)}% participation required)</RedText>
+              {participationPct}%{' '}
+              <Text size="small" color={theme.negative}>
+                ({minParticipationPct / 10 ** 16}% required)
+              </Text>
             </p>
           </div>
           <div>
@@ -263,7 +266,15 @@ class VotePanelContent extends React.Component {
                   </SliderAndValueContainer>
                 </div>
               ))}
-              <SecondRedText>{remaining} remaining</SecondRedText>
+              <Text
+                size="small"
+                color={theme.negative}
+                style={{
+                  float: 'right'
+                }}
+              >
+                {remaining} remaining
+              </Text>
               <SubmitButton mode="strong" wide onClick={this.handleVoteSubmit}>
                 Submit Vote
               </SubmitButton>
@@ -329,7 +340,7 @@ const ValueContainer = styled.div`
   border-radius: 3px;
   width: 69px;
   height: 40px;
-  border: 1px solid #e6e6e6;
+  border: 1px solid ${theme.contentBorder};
   padding-top: 0.5rem;
   text-align: center;
 `
@@ -357,16 +368,6 @@ const ShowText = styled.p`
   text-decoration: underline;
   margin-top: 1rem;
   cursor: pointer;
-`
-
-const RedText = styled.span`
-  color: #e31733;
-  font-size: 14px;
-`
-
-const SecondRedText = RedText.extend`
-  float: right;
-  margin-top: 0.5rem;
 `
 
 const Part = styled.div`

--- a/apps/range-voting/app/components/Panels/VotePanelContent.js
+++ b/apps/range-voting/app/components/Panels/VotePanelContent.js
@@ -47,10 +47,10 @@ class VotePanelContent extends React.Component {
   }
   handleVoteSubmit = () => {
     let optionsArray = []
-    this.state.voteOptions.forEach((element) => {
-      let voteWeight = element.sliderValue ? 
-        element.sliderValue * this.state.userBalance :
-        0
+    this.state.voteOptions.forEach(element => {
+      let voteWeight = element.sliderValue
+        ? element.sliderValue * this.state.userBalance
+        : 0
       optionsArray.push(voteWeight)
     })
     this.props.onVote(this.props.vote.voteId, optionsArray)
@@ -129,7 +129,7 @@ class VotePanelContent extends React.Component {
     }
 
     const { endDate, open, quorum, support } = vote
-    const {participationPct, canExecute} = vote.data
+    const { participationPct, canExecute } = vote.data
     const {
       creator,
       metadata,
@@ -253,14 +253,14 @@ class VotePanelContent extends React.Component {
                           margin: '0.5rem 0 1rem 0'
                         }}
                       >
-                      <Slider
+                        <Slider
                           width="270px"
-                        value={option.sliderValue}
-                        onUpdate={value => this.sliderUpdate(value, idx)}
-                      />
-                    <ValueContainer>
-                      {Math.round(option.sliderValue * 100) || 0}
-                    </ValueContainer>
+                          value={option.sliderValue}
+                          onUpdate={value => this.sliderUpdate(value, idx)}
+                        />
+                        <ValueContainer>
+                          {Math.round(option.sliderValue * 100) || 0}
+                        </ValueContainer>
                       </div>
                     </div>
                   </SliderAndValueContainer>
@@ -288,7 +288,7 @@ class VotePanelContent extends React.Component {
             <SidePanelSeparator />
           </div>
         )}
-        {(!open) && (
+        {!open && (
           <div>
             <SubmitButton mode="strong" wide onClick={this.executeVote}>
               Execute Vote
@@ -368,6 +368,11 @@ const ShowText = styled.p`
   text-decoration: underline;
   margin-top: 1rem;
   cursor: pointer;
+`
+
+const SecondRedText = styled(Text)`
+  float: right;
+  margin-top: 0.5rem;
 `
 
 const Part = styled.div`

--- a/apps/range-voting/app/components/Slider.js
+++ b/apps/range-voting/app/components/Slider.js
@@ -1,0 +1,224 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { Spring, animated } from 'react-spring'
+import { springs, unselectable } from '@aragon/ui'
+
+const BAR_HEIGHT = 6
+const HANDLE_SIZE = 24
+const HANDLE_SHADOW_MARGIN = 15
+const PADDING = 5
+const MIN_WIDTH = HANDLE_SIZE * 10
+const HEIGHT = Math.max(HANDLE_SIZE, BAR_HEIGHT) + PADDING * 2
+
+class Slider extends React.Component {
+  static propTypes = {
+    value: PropTypes.number,
+    onUpdate: PropTypes.func,
+    width: PropTypes.string
+  }
+  static defaultProps = {
+    value: 0,
+    onUpdate: () => {}
+  }
+  state = {
+    pressed: false
+  }
+  componentWillUnmount() {
+    this.dragStop()
+  }
+  handleRef = element => {
+    this._mainElement = element
+    this._document = element && element.ownerDocument
+  }
+  getRect = () => {
+    const now = Date.now()
+
+    // Cache the rect if the last poll was less than a second ago
+    if (this._lastRect && now - this._lastRectTime < 1000) {
+      return this._lastRect
+    }
+
+    this._lastRectTime = now
+    this._lastRect = this._mainElement
+      ? this._mainElement.getBoundingClientRect()
+      : new window.DOMRect()
+
+    return this._lastRect
+  }
+  clientXFromEvent(event) {
+    return (event.touches ? event.touches.item(0) : event).clientX
+  }
+  updateValueFromClientX(clientX) {
+    const rect = this.getRect()
+    const x = Math.min(rect.width, Math.max(0, clientX - rect.x))
+    this.props.onUpdate(x / rect.width)
+  }
+  dragStart = event => {
+    this.dragStop()
+    const clientX = this.clientXFromEvent(event)
+    this.setState({ pressed: true }, () => {
+      this.updateValueFromClientX(clientX)
+    })
+    this._document.addEventListener('mouseup', this.dragStop)
+    this._document.addEventListener('touchend', this.dragStop)
+    this._document.addEventListener('mousemove', this.dragMove)
+    this._document.addEventListener('touchmove', this.dragMove)
+  }
+  dragStop = () => {
+    this.setState({ pressed: false })
+    this._document.removeEventListener('mouseup', this.dragStop)
+    this._document.removeEventListener('touchend', this.dragStop)
+    this._document.removeEventListener('mousemove', this.dragMove)
+    this._document.removeEventListener('touchmove', this.dragMove)
+  }
+  dragMove = event => {
+    if (!this.state.pressed) {
+      return
+    }
+
+    this.updateValueFromClientX(this.clientXFromEvent(event))
+  }
+  getHandleStyles(pressProgress) {
+    return {
+      transform: pressProgress.interpolate(
+        t => `translate3d(0, calc(${t}px - 50%), 0)`
+      ),
+      boxShadow: pressProgress.interpolate(
+        t => `0 4px 8px 0 rgba(0, 0, 0, ${0.13 * (1 - t)})`
+      ),
+      background: pressProgress.interpolate(
+        t => `hsl(0, 0%, ${100 * (1 - t * 0.01)}%)`
+      )
+    }
+  }
+  getHandlePositionStyles(value) {
+    return {
+      transform: value.interpolate(
+        t => `translate3d(calc(${t * 100}% + ${HANDLE_SHADOW_MARGIN}px), 0, 0)`
+      )
+    }
+  }
+  getActiveBarStyles(value, pressProgress) {
+    return {
+      transform: value.interpolate(t => `scaleX(${t}) translateZ(0)`),
+      background: pressProgress.interpolate(
+        t => `hsl(179, ${Math.round(76 * (1 + 0.2 * t))}%, 48%)`
+      )
+    }
+  }
+  render() {
+    const { pressed } = this.state
+    const value = Math.max(0, Math.min(1, this.props.value))
+    return (
+      <Spring
+        config={springs.swift}
+        to={{
+          pressProgress: Number(pressed),
+          value
+        }}
+        native
+      >
+        {({ value, pressProgress }) => (
+          <Main>
+            <Area
+              width={this.props.width}
+              innerRef={this.handleRef}
+              onMouseDown={this.dragStart}
+              onTouchStart={this.dragStart}
+            >
+              <Bars>
+                <BaseBar />
+                <ActiveBar
+                  pressed={pressed}
+                  style={this.getActiveBarStyles(value, pressProgress)}
+                />
+              </Bars>
+
+              <HandleClip>
+                <HandlePosition
+                  style={this.getHandlePositionStyles(value, pressProgress)}
+                >
+                  <Handle
+                    pressed={pressed}
+                    style={this.getHandleStyles(pressProgress)}
+                  />
+                </HandlePosition>
+              </HandleClip>
+            </Area>
+          </Main>
+        )}
+      </Spring>
+    )
+  }
+}
+
+const Main = styled.div`
+  min-width: ${MIN_WIDTH}px;
+  padding: 0 ${HANDLE_SIZE / 2 + PADDING}px;
+  ${unselectable};
+`
+
+const Area = styled.div`
+  position: relative;
+  height: ${HEIGHT}px;
+  cursor: pointer;
+  width: ${({ width }) => width};
+`
+
+const Bars = styled(animated.div)`
+  position: absolute;
+  left: -15px;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  overflow: hidden;
+  border-radius: 2px;
+  height: ${BAR_HEIGHT}px;
+`
+
+const Bar = styled(animated.div)`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+`
+
+const BaseBar = styled(Bar)`
+  background: #edf3f6;
+`
+
+const ActiveBar = styled(Bar)`
+  transform-origin: 0 0;
+`
+
+const HandleClip = styled.div`
+  pointer-events: none;
+  overflow: hidden;
+  width: calc(100% + ${HANDLE_SIZE + HANDLE_SHADOW_MARGIN * 2}px);
+  height: calc(100% + ${HANDLE_SHADOW_MARGIN * 2}px);
+  transform-origin: 50% 50%;
+  transform: translate(
+    -${HANDLE_SIZE / 2 + HANDLE_SHADOW_MARGIN}px,
+    -${HANDLE_SHADOW_MARGIN}px
+  );
+`
+
+const HandlePosition = styled(animated.div)`
+  width: calc(100% - ${HANDLE_SIZE + HANDLE_SHADOW_MARGIN * 2}px);
+  height: 100%;
+  transform-origin: 50% 50%;
+`
+
+const Handle = styled(animated.div)`
+  position: absolute;
+  top: 50%;
+  left: -4px;
+  width: ${HANDLE_SIZE}px;
+  height: ${HANDLE_SIZE}px;
+  border: 0.5px solid #dcecf5;
+  border-radius: 50%;
+`
+
+export default Slider

--- a/apps/range-voting/arapp.json
+++ b/apps/range-voting/arapp.json
@@ -1,6 +1,6 @@
 {
   "appName": "range-voting.aragonpm.eth",
-  "version": "21.0.0",
+  "version": "0.0.1",
   "roles": [
     {
       "name": "Create new votes",


### PR DESCRIPTION
Each change is detailed in the individual commit.
Closes #203 
Workaround for #205 

I couldn't manage to customize AragonUI default Slider, so I needed to override the component to define custom width and align the handle and the bar to their parent container